### PR TITLE
Add option to redirect to https and set HSTS header

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ sentry_python: python2.7                                  # In the case of multi
 
 sentry_ssl_certificate:                                   # SSL certificate file - also turns on HTTPS on Nginx
 sentry_ssl_certificate_key:                               # Key file for SSL cert
+sentry_ssl_force: False                                   # enable HSTS and redirect to https version
 
 sentry_config_additional: []                              # List of additional options
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -7,7 +7,9 @@ limit_req_status 429;
 
 server {
 
+    {% if not sentry_ssl_certificate or not sentry_ssl_force %}
     listen {{sentry_port}};
+    {% endif %}
     server_name {{sentry_hostname}};
 
     {% if sentry_ssl_certificate %}
@@ -23,6 +25,10 @@ server {
     ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:50m;
+
+    {% if sentry_ssl_force %}
+    add_header Strict-Transport-Security "max-age=31536000";
+    {% endif %}
     {% endif %}
 
     access_log {{sentry_access_log}};
@@ -69,3 +75,15 @@ server {
     }
     {% endif %}
 }
+
+
+{% if sentry_ssl_certificate and sentry_ssl_force %}
+server {
+    listen {{ sentry_port|default(80) }};
+    server_name {{sentry_hostname}};
+
+    location / {
+        return 301 https://{{sentry_hostname}}$request_uri;
+    }
+}
+{% endif %}


### PR DESCRIPTION
- Ad configuration option sentry_ssl_force
- When sentry_ssl_certificate is set and sentry_ssl_force is true another webserver host is added to the nginx configuration which just redirects to the https host
- When sentry_ssl_certificate is set and sentry_ssl_force is true a HSTS header is added to the SSL nginx host
