### PR TITLE
Remove virtualenv option from pip sentry install

### DIFF
--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -28,7 +28,7 @@
   sudo_user: "{{sentry_user}}"
 
 - name: Install Sentry
-  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}}  virtualenv="{{sentry_home}}"/env
+  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}}
   sudo: yes
   sudo_user: "{{sentry_user}}"
   notify: [sentry restart]


### PR DESCRIPTION
Executable cannot be specified together with the 'virtualenv' parameter in Ansible 2.1. (see http://docs.ansible.com/ansible/pip_module.html#options)
