### PR TITLE
Remove duplicate dict key for sentry_single_organization

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,6 @@ sentry_port: 80
 sentry_url_prefix: "http://{{sentry_hostname}}"
 sentry_secret_key: 1LsmGR1DIyCJ5n2bRG5IVOFHdzEPkTKlW0RzxZVe9S0vc
 sentry_extensions: []                                     # List of sentry-extensions
-sentry_single_organization: yes
 
 # Python configuration
 sentry_python: python2.7                                  # In the case of multiple Python  installations


### PR DESCRIPTION
### Context

The dict key `sentry_single_organization` has a duplicate in the defaults. Resulting in a warning:
`/vendor/roles/lepture.sentry/defaults/main.yml, line 3, column 1, found a
duplicate dict key (sentry_single_organization).  Using last defined value
only.`
### What has been done
- Removed the first occurrence of the duplicate key 
